### PR TITLE
Fix info on how to use __clientField directive

### DIFF
--- a/relay.md
+++ b/relay.md
@@ -160,10 +160,7 @@ Anyway, you can compute the client field value from other server field:
 
 ```graphql
 fragment Example on Article {
-  body
-
-  # Relay is a bit broken now (see: https://github.com/facebook/relay/issues/2488)
-  _: body @__clientField(handle: "draft")
+  body @__clientField(handle: "draft")
 
   # this is a client field and it will contain uppercased `body` value
   draft
@@ -178,6 +175,9 @@ const DraftHandler = {
     const record = store.get(payload.dataID);
     const content = record.getValue(payload.fieldKey);
     record.setValue(content.toUpperCase(), 'draft');
+    
+    // Set the original value to handleKey, otherwise the field with @__clientField directive will be undefined
+    record.setValue(content, payload.handleKey);
   }
 };
 ```


### PR DESCRIPTION
I believe that it's actually not a bug, that field is undefined when you handle it with custom handler. Field's value is just mapped to new key (handleKey)


// btw thank you for this repo, it's absolutely the best source for relay